### PR TITLE
Fixed typo in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ else
         isroot="true"
 	themeinstallpath="/usr/share/themes"
 	iconinstallpath="/usr/share/icons"
-	echo -e "${BGre}You ran this script as root, defautl install path is set to\n'/usr/share/' which can also be changed later!${RCol}"
+	echo -e "${BGre}You ran this script as root, default install path is set to\n'/usr/share/' which can also be changed later!${RCol}"
 fi
 
 #Determine user name for later


### PR DESCRIPTION
"default" is misspelled as "defautl". commit fixes spelling