### PR TITLE
Fix backdrop typo

### DIFF
--- a/Themes/Yaru-Aqua-dark/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Aqua-dark/gtk-3.20/gtk.css
@@ -5446,7 +5446,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #d7d7d7; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Aqua/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Aqua/gtk-3.20/gtk.css
@@ -5477,7 +5477,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #fcfcfc; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Blue-dark/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Blue-dark/gtk-3.20/gtk.css
@@ -5446,7 +5446,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #d7d7d7; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Blue/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Blue/gtk-3.20/gtk.css
@@ -5477,7 +5477,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #fcfcfc; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Brown-dark/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Brown-dark/gtk-3.20/gtk.css
@@ -5446,7 +5446,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #d7d7d7; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Brown/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Brown/gtk-3.20/gtk.css
@@ -5477,7 +5477,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #fcfcfc; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Deepblue-dark/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Deepblue-dark/gtk-3.20/gtk.css
@@ -5446,7 +5446,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #d7d7d7; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Deepblue/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Deepblue/gtk-3.20/gtk.css
@@ -5477,7 +5477,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #fcfcfc; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Green-dark/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Green-dark/gtk-3.20/gtk.css
@@ -5446,7 +5446,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #d7d7d7; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Green/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Green/gtk-3.20/gtk.css
@@ -5477,7 +5477,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #fcfcfc; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Grey-dark/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Grey-dark/gtk-3.20/gtk.css
@@ -5446,7 +5446,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #d7d7d7; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Grey/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Grey/gtk-3.20/gtk.css
@@ -5477,7 +5477,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #fcfcfc; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-MATE-dark/gtk-3.20/gtk.css
+++ b/Themes/Yaru-MATE-dark/gtk-3.20/gtk.css
@@ -5446,7 +5446,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #d7d7d7; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-MATE/gtk-3.20/gtk.css
+++ b/Themes/Yaru-MATE/gtk-3.20/gtk.css
@@ -5477,7 +5477,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #fcfcfc; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Orange-dark/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Orange-dark/gtk-3.20/gtk.css
@@ -5446,7 +5446,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #d7d7d7; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Orange/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Orange/gtk-3.20/gtk.css
@@ -5477,7 +5477,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #fcfcfc; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Pink-dark/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Pink-dark/gtk-3.20/gtk.css
@@ -5446,7 +5446,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #d7d7d7; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Pink/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Pink/gtk-3.20/gtk.css
@@ -5477,7 +5477,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #fcfcfc; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Purple-dark/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Purple-dark/gtk-3.20/gtk.css
@@ -5446,7 +5446,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #d7d7d7; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Purple/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Purple/gtk-3.20/gtk.css
@@ -5477,7 +5477,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #fcfcfc; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Red-dark/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Red-dark/gtk-3.20/gtk.css
@@ -5446,7 +5446,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #d7d7d7; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Red/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Red/gtk-3.20/gtk.css
@@ -5477,7 +5477,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #fcfcfc; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Yellow-dark/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Yellow-dark/gtk-3.20/gtk.css
@@ -5446,7 +5446,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #d7d7d7; }
 
 button.titlebutton:not(.appmenu) {

--- a/Themes/Yaru-Yellow/gtk-3.20/gtk.css
+++ b/Themes/Yaru-Yellow/gtk-3.20/gtk.css
@@ -5477,7 +5477,7 @@ spinner:not(:backdrop) {
 
 button.suggested-action spinner, button.destructive-action spinner {
   color: #ffffff; }
-  button.suggested-action spinner:backrop, button.destructive-action spinner:backrop {
+  button.suggested-action spinner:backdrop, button.destructive-action spinner:backdrop {
     color: #fcfcfc; }
 
 button.titlebutton:not(.appmenu) {


### PR DESCRIPTION
I saw an error about an invalid pseudo-class in the gtk.css file. I looked and it seems as though "backdrop" was misspelled as "backrop".