### PR TITLE
Fix: PURPLE Color should be used, not ORANGE(Base) Color

### DIFF
--- a/src/theme-script.sh
+++ b/src/theme-script.sh
@@ -602,7 +602,7 @@ sed -i -e "s/E95420/$base_col/g" $source32_path/_palette.scss
 #Obsolete purple color for <20.04 - newer below
 sed -i -e "s/762572/$purple_col/g" $source32_path/_palette.scss
 #Addition for 20.04 - new purple color is $aubergine = #924D8B!
-sed -i -e "s/924D8B/$base_col/g" $source32_path/_palette.scss
+sed -i -e "s/924D8B/$purple_col/g" $source32_path/_palette.scss
 
 echo -e "Find and replace the color values in _colors.scss ..."
 #replace the color values in _colors.scss
@@ -706,7 +706,7 @@ cd $source30_path
 ##Obsolete purple color for <20.04 - newer below
 #sed -i -e "s/762572/$purple_col/g" $source30_path/_ubuntu-colors.scss
 ##Addition for 20.04 - new purple color is $aubergine = #924D8B!
-#sed -i -e "s/924D8B/$base_col/g" $source30_path/_ubuntu-colors.scss
+#sed -i -e "s/924D8B/$purple_col/g" $source30_path/_ubuntu-colors.scss
 
 #echo -e "Find and replace the color values in _colors.scss ..."
 #replace the color values in _colors.scss
@@ -941,7 +941,7 @@ sed -i -e "s/E95420/$base_col/g" $sass_path/_palette.scss
 #Obsolete purple color for <20.04 - newer below
 sed -i -e "s/300A24/$purple_col/g" $sass_path/_palette.scss
 #Addition for 20.04 - new purple color is $aubergine = #924D8B!
-sed -i -e "s/924D8B/$base_col/g" $sass_path/_palette.scss
+sed -i -e "s/924D8B/$purple_col/g" $sass_path/_palette.scss
 
 echo -e " "
 echo -e "Compiling gnome-shell theme ..."


### PR DESCRIPTION
Fix issue #70 

In the file "src/theme-script.sh", according the comment:

    #Addition for 20.04 - new purple color is $aubergine = #924D8B!

purple color #924D8B should be replaced by "$purple_col".
But the actual code is using "$base_col":

    sed -i -e "s/924D8B/$base_col/g" $source32_path/_palette.scss

It should be **"$purple_col":**

    sed -i -e "s/924D8B/$purple_col/g" $source32_path/_palette.scss

So I patched the "src/theme-script.sh".